### PR TITLE
Add basic Flask route tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import sys
+import types
+
+# Create stub modules to satisfy imports in webapp
+src_pkg = types.ModuleType('src')
+reporting_pkg = types.ModuleType('src.reporting')
+constants_pkg = types.ModuleType('src.constants')
+
+comp_mod = types.ModuleType('src.reporting.comprehensive_report_generator')
+prof_mod = types.ModuleType('src.reporting.profile_graph_generator')
+
+class DummyReportGen:
+    def __init__(self, *args, **kwargs):
+        pass
+    def generate_report(self, *args, **kwargs):
+        return {}
+
+class DummyGraphGen:
+    def __init__(self, *args, **kwargs):
+        pass
+    def generate_all_graphs(self, *args, **kwargs):
+        return {}
+
+comp_mod.ComprehensiveReportGenerator = DummyReportGen
+prof_mod.ProfileGraphGenerator = DummyGraphGen
+
+scale_constants_mod = types.ModuleType('src.constants.scale_constants')
+scale_constants_mod.VALIDITY_SCALES_MAP = {'L': 'Lie'}
+scale_constants_mod.CLINICAL_SCALES_MAP = {'1': 'Hs'}
+scale_constants_mod.HARRIS_LINGOES_SUBSCALES_MAP = {}
+scale_constants_mod.CONTENT_SCALES_MAP = {}
+scale_constants_mod.RC_SCALES_MAP = {}
+scale_constants_mod.PSY5_SCALES_MAP = {}
+scale_constants_mod.SUPPLEMENTARY_SCALES_MAP = {}
+
+# Register modules in sys.modules
+sys.modules['src'] = src_pkg
+sys.modules['src.reporting'] = reporting_pkg
+sys.modules['src.reporting.comprehensive_report_generator'] = comp_mod
+sys.modules['src.reporting.profile_graph_generator'] = prof_mod
+sys.modules['src.constants'] = constants_pkg
+sys.modules['src.constants.scale_constants'] = scale_constants_mod
+
+# Expose submodules on packages
+reporting_pkg.comprehensive_report_generator = comp_mod
+reporting_pkg.profile_graph_generator = prof_mod
+constants_pkg.scale_constants = scale_constants_mod

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,30 @@
+import pytest
+from webapp import app
+from flask import url_for
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_index_route(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b"MMPI-2 Assessment Platform" in resp.data
+
+def test_client_info_route(client):
+    resp = client.get('/client_info')
+    assert resp.status_code == 200
+    assert b"Client Information" in resp.data or b"Client Information Entry" in resp.data
+
+def test_score_entry_route(client):
+    resp = client.get('/score_entry')
+    assert resp.status_code == 200
+    assert b"T-Score Entry" in resp.data or b"Enter MMPI-2 T-Scores" in resp.data
+
+def test_view_report_redirect(client):
+    resp = client.get('/view_report/nonexistent')
+    # should redirect to index
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith(url_for('index'))


### PR DESCRIPTION
## Summary
- add `pytest.ini`
- create testing stubs in `tests/conftest.py`
- add Flask route tests for the main pages

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*