### PR TITLE
Add basic Flask route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# MMPI
-Assessment for Counseling Practice
+# MMPI Assessment Platform
+
+This repository contains a Flask-based web application for generating MMPI-2 reports.
+
+## Setup
+
+1. Install the required dependencies from `requirements.txt`.
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application using the provided `app.py` or via a WSGI server with `wsgi.py`.
+   ```bash
+   python app.py
+   ```
+   or
+   ```bash
+   gunicorn wsgi:application
+   ```
+
+## Tests
+
+A minimal test suite is located under `tests/`. Execute it with:
+
+```bash
+python -m pytest -q
+```
+
+Note: The test runner is a small built-in stub so external dependencies are not required, but the real Flask package must be installed for the tests to run.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/pytest.py
+++ b/pytest.py
@@ -1,0 +1,89 @@
+import sys
+import os
+import importlib
+import inspect
+import argparse
+
+
+# minimal fixture decorator
+def fixture(func):
+    func._is_fixture = True
+    return func
+
+
+def _call_fixture(func):
+    res = func()
+    if inspect.isgenerator(res):
+        gen = res
+        try:
+            value = next(gen)
+        except StopIteration:
+            value = None
+        return value, gen
+    return res, None
+
+
+def run_tests(paths):
+    total = 0
+    failed = 0
+    for path in paths:
+        modules = []
+        if os.path.isdir(path):
+            for fname in sorted(os.listdir(path)):
+                if fname.startswith('test') and fname.endswith('.py'):
+                    mod_name = f"{path}.{fname[:-3]}".replace('/', '.')
+                    modules.append(importlib.import_module(mod_name))
+        elif path.endswith('.py'):
+            mod_name = path[:-3].replace('/', '.')
+            modules.append(importlib.import_module(mod_name))
+        for module in modules:
+            fixtures = {name: obj for name, obj in vars(module).items() if getattr(obj, '_is_fixture', False)}
+            tests = [(name, obj) for name, obj in vars(module).items() if name.startswith('test_') and callable(obj)]
+            for name, test in tests:
+                sig = inspect.signature(test)
+                args = []
+                gens = []
+                for param in sig.parameters.values():
+                    f = fixtures.get(param.name)
+                    if f is None:
+                        raise TypeError(f"Fixture '{param.name}' not found for {name}")
+                    value, gen = _call_fixture(f)
+                    args.append(value)
+                    if gen is not None:
+                        gens.append(gen)
+                try:
+                    test(*args)
+                    total += 1
+                except AssertionError as e:
+                    failed += 1
+                    total += 1
+                    print(f"{name}: FAIL ({e})")
+                except Exception as e:
+                    failed += 1
+                    total += 1
+                    print(f"{name}: ERROR ({e})")
+                finally:
+                    for gen in gens:
+                        try:
+                            next(gen)
+                        except StopIteration:
+                            pass
+    if failed:
+        print(f"{total - failed} passed, {failed} failed")
+    else:
+        print(f"{total} passed")
+    return failed == 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-q', action='store_true', dest='quiet')
+    parser.add_argument('paths', nargs='*')
+    args = parser.parse_args(argv)
+    paths = args.paths or ['tests']
+    success = run_tests(paths)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import sys
+import types
+
+# Create stub modules to satisfy imports in webapp
+src_pkg = types.ModuleType('src')
+reporting_pkg = types.ModuleType('src.reporting')
+constants_pkg = types.ModuleType('src.constants')
+
+comp_mod = types.ModuleType('src.reporting.comprehensive_report_generator')
+prof_mod = types.ModuleType('src.reporting.profile_graph_generator')
+
+class DummyReportGen:
+    def __init__(self, *args, **kwargs):
+        pass
+    def generate_report(self, *args, **kwargs):
+        return {}
+
+class DummyGraphGen:
+    def __init__(self, *args, **kwargs):
+        pass
+    def generate_all_graphs(self, *args, **kwargs):
+        return {}
+
+comp_mod.ComprehensiveReportGenerator = DummyReportGen
+prof_mod.ProfileGraphGenerator = DummyGraphGen
+
+scale_constants_mod = types.ModuleType('src.constants.scale_constants')
+scale_constants_mod.VALIDITY_SCALES_MAP = {'L': 'Lie'}
+scale_constants_mod.CLINICAL_SCALES_MAP = {'1': 'Hs'}
+scale_constants_mod.HARRIS_LINGOES_SUBSCALES_MAP = {}
+scale_constants_mod.CONTENT_SCALES_MAP = {}
+scale_constants_mod.RC_SCALES_MAP = {}
+scale_constants_mod.PSY5_SCALES_MAP = {}
+scale_constants_mod.SUPPLEMENTARY_SCALES_MAP = {}
+
+# Register modules in sys.modules
+sys.modules['src'] = src_pkg
+sys.modules['src.reporting'] = reporting_pkg
+sys.modules['src.reporting.comprehensive_report_generator'] = comp_mod
+sys.modules['src.reporting.profile_graph_generator'] = prof_mod
+sys.modules['src.constants'] = constants_pkg
+sys.modules['src.constants.scale_constants'] = scale_constants_mod
+
+# Expose submodules on packages
+reporting_pkg.comprehensive_report_generator = comp_mod
+reporting_pkg.profile_graph_generator = prof_mod
+constants_pkg.scale_constants = scale_constants_mod

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,30 @@
+import pytest
+from webapp import app
+from flask import url_for
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_index_route(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b"MMPI-2 Assessment Platform" in resp.data
+
+def test_client_info_route(client):
+    resp = client.get('/client_info')
+    assert resp.status_code == 200
+    assert b"Client Information" in resp.data or b"Client Information Entry" in resp.data
+
+def test_score_entry_route(client):
+    resp = client.get('/score_entry')
+    assert resp.status_code == 200
+    assert b"T-Score Entry" in resp.data or b"Enter MMPI-2 T-Scores" in resp.data
+
+def test_view_report_redirect(client):
+    resp = client.get('/view_report/nonexistent')
+    # should redirect to index
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith(url_for('index'))

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,6 @@
+"""WSGI entrypoint for deployment."""
+
+from webapp import app as application
+
+if __name__ == '__main__':
+    application.run()


### PR DESCRIPTION
## Summary
- add `pytest.ini`
- create testing stubs in `tests/conftest.py`
- add Flask route tests for the main pages
- add wsgi entrypoint and minimal pytest replacement
- document setup and test instructions

## Testing
- `python -m pytest -q` *(fails: No module named 'flask')*