### PR TITLE
Expose legacy MMPI questionnaire

### DIFF
--- a/README_app.md
+++ b/README_app.md
@@ -58,6 +58,8 @@ This web application provides a comprehensive platform for administering, scorin
 4. **Using the Application**
    - Enter client information (name, age, sex, etc.)
    - Input T-scores for all relevant scales
+   - Alternatively, open the legacy questionnaire via `/mmpi_test` to complete
+     the full MMPI-2 in your browser
    - Generate comprehensive report
    - View and download reports in multiple formats
 

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
                         </ul>
                         <div class="d-grid gap-2">
                             <a href="{{ url_for('client_info') }}" class="btn btn-primary">Start New Assessment</a>
+                            <a href="{{ url_for('mmpi_test') }}" class="btn btn-primary">Take MMPI-2 Test</a>
                             <a href="{{ url_for('sample_data') }}" class="btn btn-outline-primary">Load Male Sample Data</a>
                             <a href="{{ url_for('female_sample_data') }}" class="btn btn-outline-primary">Load Female Sample Data</a>
                         </div>

--- a/webapp.py
+++ b/webapp.py
@@ -212,6 +212,12 @@ def report_file(report_id, filename):
     report_dir = os.path.join(app.config['REPORT_FOLDER'], report_id)
     return send_from_directory(report_dir, filename)
 
+# Serve the original MMPI questionnaire page
+@app.route('/mmpi_test', methods=['GET'])
+def mmpi_test():
+    """Serve the legacy MMPI HTML questionnaire."""
+    return send_from_directory('.', 'mmpi copy.html')
+
 @app.route('/sample_data', methods=['GET'])
 def sample_data():
     """Load sample data for demonstration."""


### PR DESCRIPTION
## Summary
- add new `/mmpi_test` route to serve the original `mmpi copy.html`
- link to the questionnaire from the home page
- document the new route in the README

## Testing
- `python -m py_compile webapp.py`
