### PR TITLE
feat: Add Docker support for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,94 @@
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Python virtual environment
+venv/
+*.venv
+.env
+env/
+ENV/
+
+# Python bytecode and cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+dist/
+build/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# IDE settings
+.idea/
+.vscode/
+
+# Archives and large document files (likely examples or non-app resources)
+*.zip
+*.docx
+MMPI Manus.zip # Specific example from ls()
+567-MMPI_questions-1.docx # Specific example from ls()
+www_kerry-lyn_com.zip # Specific example from ls()
+mmpi_platform_self_hosting.zip # Specific example from ls()
+Using Uploaded Information in AI Prompts.zip # Specific example from ls()
+
+# Screenshots (likely documentation/dev artifacts)
+Screenshot*.png
+
+# Example reports in the root directory.
+# The application generates reports into the 'reports' directory inside the container.
+# These root-level reports are assumed to be examples or test outputs.
+# (If any specific report here IS served statically by name, it should be removed from this list)
+clinical_profile_graphs.pdf
+clinical_sample_report.html
+clinical_sample_report.pdf
+clinical_sample_report.txt
+comparison_sample_female_report.pdf
+comparison_sample_female_report.txt
+comparison_sample_female_traditional_profile_graph.png
+comparison_sample_male_report.pdf
+comparison_sample_male_report.txt
+comparison_sample_male_traditional_profile_graph.png
+comprehensive_report.pdf # Example: comprehensive_report.txt is used in a test
+# comprehensive_report.txt # Used in test_comprehensive_report_generator.py, keep for now if tests run in Docker
+dsm5tr_sample_report.pdf
+embedded_graphs_report.html
+embedded_graphs_report.pdf
+enhanced_clinical_report.html
+enhanced_clinical_report.pdf
+# enhanced_clinical_report.txt # Used in test_enhanced_clinical_report.py, keep for now
+final_comprehensive_report.html
+final_comprehensive_report.pdf
+# final_comprehensive_report.txt # Used in test_final_comprehensive_report_generator.py, keep for now
+revised_clinical_report.html
+revised_clinical_report.pdf
+# revised_clinical_report.txt # Used in test_revised_clinical_report.py, keep for now
+scale_family_graphs.pdf
+traditional_profile_graph.pdf
+traditional_profile_graph.png # Example: traditional_profile_graph.png is used in a test
+
+# HTML copies in root, except mmpi_copy.html which is served
+mmpi copy-17.html
+mmpi copy-18.html
+mmpi copy-19.html
+
+# Local development/testing artifacts if any
+*.log
+local_settings.py
+pasted_content.txt # Example from ls()
+pasted_content_2.txt # Example from ls()
+pasted_content_3.txt # Example from ls()
+
+# Do not ignore test files yet, they might be run in a later Docker stage or for verification.
+# If any .py files are truly standalone utility scripts not imported by the webapp,
+# they could be ignored, but it's safer to include them for now. Examples:
+# create_clinical_sample.py
+# dsm5tr_sample_generator.py
+# etc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies that might be needed by WeasyPrint
+# This is a common set; adjust if specific errors arise during build or runtime
+RUN apt-get update && apt-get install -y --no-install-recommends     build-essential     libffi-dev     libpango1.0-0     libharfbuzz0b     libfontconfig1     libjpeg-dev     zlib1g-dev     && rm -rf /var/lib/apt/lists/*
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's source code from the current directory to the working directory
+COPY . .
+
+# Create directories for reports and uploads
+# These directories will be created within the /app directory
+RUN mkdir -p reports uploads
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Define the command to run the application
+# Ensure webapp:app correctly points to your Flask app instance in webapp.py
+# The user running Gunicorn inside the container should have write access to /app/reports and /app/uploads
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "webapp:app"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn webapp:app --log-file -

--- a/README_app.md
+++ b/README_app.md
@@ -84,3 +84,44 @@ The application includes sample data for both male and female profiles with iden
 
 For educational and clinical use only.
 """
+
+## Deployment
+
+This application is designed to be deployed using Docker, which packages the application and all its dependencies into a container.
+
+### Using Docker
+
+1.  **Build the Docker Image**:
+    Navigate to the root directory of the project (where the `Dockerfile` is located) and run:
+    ```bash
+    docker build -t mmpi-app .
+    ```
+    This will build a Docker image tagged as `mmpi-app`.
+
+2.  **Run the Docker Container**:
+    Once the image is built, you can run it as a container:
+    ```bash
+    docker run -p 8080:8080 -e SECRET_KEY='your_very_strong_and_unique_secret_key' mmpi-app
+    ```
+    Breakdown of the command:
+    *   `-p 8080:8080`: Maps port 8080 from your host machine to port 8080 in the container (where Gunicorn is running). You can change the host port if needed (e.g., `-p 5000:8080`).
+    *   `-e SECRET_KEY='your_very_strong_and_unique_secret_key'`: Sets the `SECRET_KEY` environment variable inside the container. **Important:** Replace `'your_very_strong_and_unique_secret_key'` with a strong, unique secret key for your production deployment.
+    *   `mmpi-app`: The name of the Docker image to run.
+
+    The application should then be accessible at `http://localhost:8080` (or whichever host port you used).
+
+### Hosting the Application
+
+To deploy this application on the web, you will need a hosting service that can run Docker containers. Some options include:
+
+*   **Platform as a Service (PaaS)**: Heroku (using Docker deploy), Google Cloud Run, AWS Elastic Beanstalk, Azure App Service.
+*   **Virtual Private Server (VPS)**: DigitalOcean, Linode, AWS EC2. You would install Docker on the VPS and run the container.
+*   **Managed Kubernetes Services**: Google Kubernetes Engine (GKE), Amazon EKS, Azure Kubernetes Service (AKS).
+
+### Note on GitHub Pages
+
+GitHub Pages is designed for hosting **static websites** (HTML, CSS, JavaScript files). It cannot run Python web applications like this Flask app directly.
+
+If you wish to use GitHub Pages, you would typically:
+*   Deploy the dynamic Python Flask application to a suitable hosting service (as mentioned above).
+*   Optionally, use GitHub Pages for a related static landing page, documentation, or a version of the questionnaire that communicates with the separately hosted backend via APIs (though this application is not currently structured for that kind of split). The existing `mmpi_copy.html` could be served via GitHub Pages as a static page, but it wouldn't have the Python backend functionality.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ itsdangerous==2.2.0
 click==8.2.0
 MarkupSafe==3.0.2
 blinker==1.9.0
+gunicorn

--- a/webapp.py
+++ b/webapp.py
@@ -25,7 +25,7 @@ from src.constants.scale_constants import (
 # Create Flask app
 # HTML templates now live in the standard ./templates directory
 app = Flask(__name__)
-app.secret_key = os.urandom(24)
+app.secret_key = os.environ.get('SECRET_KEY', 'dev_secret_key')
 app.config['UPLOAD_FOLDER'] = 'uploads'
 app.config['REPORT_FOLDER'] = 'reports'
 


### PR DESCRIPTION
This commit introduces Dockerization to the MMPI assessment application, enabling easier and more consistent deployments.

Key changes include:
- Added `gunicorn` to `requirements.txt` as a production WSGI server.
- Updated `webapp.py` to use an environment variable for `SECRET_KEY` for improved security, with a development fallback.
- Created a `Dockerfile` to define the application image, including Python, system dependencies for WeasyPrint, and application code. Gunicorn is used as the entry point.
- Added a `.dockerignore` file to optimize Docker image builds by excluding unnecessary files.
- Created a `Procfile` for compatibility with PaaS platforms like Heroku.
- Updated `README_app.md` with a comprehensive "Deployment" section, detailing how to build and run the Docker container and clarifying hosting options and the limitations of GitHub Pages for this type of application.

These changes provide a robust foundation for deploying the Flask application in various container-supporting environments.